### PR TITLE
feat: remove the 'vue/no-undef-components' rule from the Vue configuration

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1460,8 +1460,8 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
-  vite@6.3.0:
-    resolution: {integrity: sha512-9aC0n4pr6hIbvi1YOpFjwQ+QOTGssvbJKoeYkuHHGWwlXfdxQlI8L2qNMo9awEEcCPSiS+5mJZk5jH1PAqoDeQ==}
+  vite@6.3.1:
+    resolution: {integrity: sha512-kkzzkqtMESYklo96HKKPE5KKLkC1amlsqt+RjFMlX2AvbRB/0wghap19NdBxxwGZ+h/C6DLCrcEphPIItlGrRQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -2037,13 +2037,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.1.1(vite@6.3.0(@types/node@22.14.1)(jiti@2.4.2))':
+  '@vitest/mocker@3.1.1(vite@6.3.1(@types/node@22.14.1)(jiti@2.4.2))':
     dependencies:
       '@vitest/spy': 3.1.1
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.3.0(@types/node@22.14.1)(jiti@2.4.2)
+      vite: 6.3.1(@types/node@22.14.1)(jiti@2.4.2)
 
   '@vitest/pretty-format@3.1.1':
     dependencies:
@@ -2893,7 +2893,7 @@ snapshots:
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 6.3.0(@types/node@22.14.1)(jiti@2.4.2)
+      vite: 6.3.1(@types/node@22.14.1)(jiti@2.4.2)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -2908,7 +2908,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.3.0(@types/node@22.14.1)(jiti@2.4.2):
+  vite@6.3.1(@types/node@22.14.1)(jiti@2.4.2):
     dependencies:
       esbuild: 0.25.2
       fdir: 6.4.3(picomatch@4.0.2)
@@ -2924,7 +2924,7 @@ snapshots:
   vitest@3.1.1(@types/node@22.14.1)(@vitest/ui@3.1.1)(jiti@2.4.2):
     dependencies:
       '@vitest/expect': 3.1.1
-      '@vitest/mocker': 3.1.1(vite@6.3.0(@types/node@22.14.1)(jiti@2.4.2))
+      '@vitest/mocker': 3.1.1(vite@6.3.1(@types/node@22.14.1)(jiti@2.4.2))
       '@vitest/pretty-format': 3.1.1
       '@vitest/runner': 3.1.1
       '@vitest/snapshot': 3.1.1
@@ -2940,7 +2940,7 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.3.0(@types/node@22.14.1)(jiti@2.4.2)
+      vite: 6.3.1(@types/node@22.14.1)(jiti@2.4.2)
       vite-node: 3.1.1(@types/node@22.14.1)(jiti@2.4.2)
       why-is-node-running: 2.3.0
     optionalDependencies:

--- a/src/configs/vue.ts
+++ b/src/configs/vue.ts
@@ -22,7 +22,6 @@ function getVueConfigs(): Config[] {
         'vue/no-root-v-if': 'warn',
         'vue/no-setup-props-reactivity-loss': 'warn',
         'vue/no-template-target-blank': 'warn',
-        'vue/no-undef-components': 'warn',
         'vue/no-use-v-else-with-v-for': 'warn',
         'vue/no-useless-mustaches': 'warn',
         'vue/no-useless-v-bind': 'warn',


### PR DESCRIPTION
Bump the version of Vite and remove the 'vue/no-undef-components' rule from the Vue configuration to streamline component usage.